### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jenspapenhagen/upload_frontend/security/code-scanning/1](https://github.com/jenspapenhagen/upload_frontend/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block at the root of the workflow file to define the minimal privileges required for the workflow. Since the workflow involves typical CI tasks like checking out code, installing dependencies, running builds, tests, and linting, the only required permission is `contents: read`. This ensures that the workflow has read-only access to the repository contents and does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
